### PR TITLE
Formatting of local %increased phys mods

### DIFF
--- a/src/stat_translation.ml
+++ b/src/stat_translation.ml
@@ -254,7 +254,7 @@ let values_for_mode translation = function
       let get_value stat_id =
         match Id.Map.find_opt stat_id ranges with
           | None ->
-              (-9999)
+              0
           | Some (min, max) ->
               (min + max) / 2
       in
@@ -263,14 +263,12 @@ let values_for_mode translation = function
       let get_value stat_id =
         match Id.Map.find_opt stat_id values with
           | None ->
-              (-9999)
+              0
           | Some value ->
               value
       in
       List.map get_value translation.stats
 
-(* TODO: doesn't work for LocalIncreasedPhysicalDamagePercentAndPierceInfluence4_
-   (reproduce with: kalandralang find 'pierce*target' *)
 let translate_one mode translation =
   if
     let rec matches values conditions =


### PR DESCRIPTION
Currently, local %phys mods such as "LocalIncreasedPhysicalDamagePercent8" or "LocalIncreasedPhysicalDamagePercentAndPierceInfluence4_" display as "No Physical Damage" (either through kalandralang find or when displaying an item with these mods).

This is caused by using a default value of -9999 for a stat when it is not present (in Stat_translation.translate_one and Stat_translation.values_for_mode) which causes kalandralang to assume there is a "local_weapon_no_physical_damage" stat accompanying the "local_physical_damage_+%" (matching the condition listed here: data/stat_translations.json:22666-22681).
Replacing -9999 by 0 solves the issue (matching the condition listed here: data/stat_translations.json:22700-22718).