### PR TITLE
Fix awaken orb bug, same influence

### DIFF
--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -315,6 +315,7 @@ let apply_currency state (currency: AST.currency) =
         in
         let item_influence = get_sec_influence "current item" item in
         let aside_influence = get_sec_influence "item set aside" aside in
+        if item_influence = aside_influence then fail "Current and item set aside have the same influence";
         let random_influenced_mod_from (item: Item.t) influence =
           match Base_tag.get_influence_tag_for_tags item.base.tags influence with
             | None ->


### PR DESCRIPTION
The awakeners orb was usable  on items with same influence.