### PR TITLE
Refactoring Data / Http-Requests

### DIFF
--- a/src/data.ml
+++ b/src/data.ml
@@ -1,0 +1,165 @@
+open Misc
+
+type paths =
+  {
+      data_path: string;
+      cache: string;
+      costs: string;
+  }
+
+let poe_data = [
+  ( (Base_item.load),        "base_items.json" );
+  ( (Mod.load),              "mods.json" );
+  ( (Stat_translation.load), "stat_translations.json" );
+  ( (Essence.load),          "essences.json" );
+]
+
+let getPaths data_dir =
+  let data_path = 
+    if data_dir = String.empty then
+      match Sys.os_type with
+        | "Unix" ->
+            let userid = Unix.getuid () in
+            let home = (Unix.getpwuid userid).pw_dir in
+            let kld_path = Filename.concat home ".kalandralang" in
+            let result = Filename.concat kld_path "data/" in
+            result
+        | "Win32" ->
+            (* Not implemented, use current folder for data *)
+            "data/"
+        | "Cygwin" ->
+            (* Not implemented, use current folder for data *)
+            "data/"
+        | _ ->
+            "data/"
+    else
+      data_dir
+  in
+  let () = 
+    Misc.mkdir_p ~path:data_path ~perms:0o755;
+  in
+  let genPath file = Filename.concat data_path file in
+  let cache = genPath "kalandralang.cache" in
+  let costs = genPath "costs.json" in
+  {
+    data_path; 
+    cache; 
+    costs;
+  }
+
+let update_poe_data_file filepath =
+  let filename = Filename.basename filepath in
+  let etag_file = filepath ^ ".etag" in
+    let etag =
+      if Sys.file_exists etag_file then (
+        let ic = open_in etag_file in
+        let etag = input_line ic in
+        close_in ic;
+        etag
+      ) else
+        ""
+    in
+    let request_etag =
+      let headers = 
+        Http_request.header_create()
+        |>Http_request.header_add "If-None-Match" etag
+      in
+      echo "Checking/Downloading %s" filename;
+      Uri.of_string("https://raw.githubusercontent.com/brather1ng/RePoE/master/RePoE/data/" ^ filename)
+      |>Http_request.download ~headers filepath 
+      |>Http_request.get_header "etag"
+    in
+    let write_etag etag = 
+      let oc = open_out etag_file in
+      Printf.fprintf oc "%s" etag;
+      close_out oc;
+    in
+    match request_etag with
+      | Some request_etag -> 
+        if request_etag <> etag then (
+          echo " - %s got updated." filename;
+          write_etag request_etag
+        ) else (
+          echo " - %s is up to date." filename
+        )
+      | _ -> 
+        (* Should never happen *)
+        fail "Could not retrieve ETag from download.."
+
+let load_data data_dir = 
+  let path = getPaths data_dir in
+    let module_load mdl filepath = 
+      let filename = Filename.basename filepath in
+      echo "Loading %s..." filename;
+      mdl filepath
+    in
+    let load_from_json () =
+      (* Loads all files and modules specified in poe_data *)
+      let rec module_load_json list =
+        match list with
+          | [] -> ()
+          | x :: xs ->
+              let (mdl, file) = x in
+              let filepath = Filename.concat path.data_path file in
+              update_poe_data_file filepath;
+              module_load mdl filepath;
+              module_load_json xs
+      in 
+      module_load_json poe_data
+    in
+    let save_to_data () =
+      (* Saving cache data to harddrive *)
+      echo "Writing %s to speed up future loadings..." path.cache;
+      Cache.export path.cache;
+    in
+    let load_from_data () = (
+      (* Tries loading Cache, true = success, false = failed *)
+      let ret = module_load (Cache.import) path.cache in
+      match ret with
+        | Failed_to_load ->
+            echo "Failed to read cache from: %s" path.cache;
+            false
+        | Wrong_version ->
+            echo "%s is from a different version and cannot be loaded." path.cache;
+            false
+        | Loaded ->
+            true
+    )
+    in (
+      if Sys.file_exists path.cache then (
+        if not (load_from_data ()) then (
+          load_from_json ();
+          save_to_data ();
+        );
+      ) else (
+        load_from_json ();
+        save_to_data ();
+      );
+    )
+
+let load data_dir = (
+    load_data data_dir;
+    let path = getPaths data_dir in
+    if Sys.file_exists path.costs then (
+      echo "Loading %s..." path.costs;
+      Cost.load path.costs;
+    ) else (
+      echo "%s does not exist, will use default values." path.costs;
+      echo "Use the 'write-default-costs' or 'update-costs' command to create it.";
+    );
+    echo "Ready.";
+  )
+
+let update_cache data_dir = 
+  let path = getPaths data_dir in
+  Sys.remove path.cache;
+  load_data data_dir;
+  echo "Done."
+
+let update_costs data_dir ~ninja_league ~tft_league =
+  let path = getPaths data_dir in
+  Ninja.write_costs ~ninja_league ~tft_league ~filename: path.costs
+
+let write_default_costs data_dir =
+  let path = getPaths data_dir in
+  Cost.write_defaults path.costs 

--- a/src/http_request.ml
+++ b/src/http_request.ml
@@ -1,0 +1,57 @@
+(* USES uri *)
+(* USES tls *)
+(* USES cohttp-lwt-unix *)
+(* USES lwt *)
+
+open Misc
+
+let (let*) = Lwt.bind
+let return = Lwt.return
+
+let get ?(headers = Cohttp.Header.init ()) uri =
+  Lwt_main.run @@
+  let* (response, response_body) = Cohttp_lwt_unix.Client.get ~headers uri in
+  let* body = Cohttp_lwt.Body.to_string response_body in
+  let code = response |> Cohttp.Response.status |> Cohttp.Code.code_of_status in
+  match code with
+    (* OK: Succuessful get request with body content *)
+    | 200 ->
+        return (response, (Some body))
+    (* Not-modified: Succuessful get request with no body content, content hasnot been modified *)
+    | 304 ->
+        return (response, None)
+    (* else report error *)
+    | _ ->
+        echo "failed to fetch %s: %s - %s"
+          (Uri.to_string uri)
+          (Cohttp.Code.string_of_status response.status)
+          body;
+        return (response, None)
+
+let get_json ?(headers = Cohttp.Header.init ()) origin = function uri ->
+  let (_, response_body) = get ~headers uri in
+    match response_body with
+      | Some response_body -> Some (JSON.parse ~origin: origin response_body)
+      | _ -> None
+
+let download ?(headers = Cohttp.Header.init ()) filepath = function uri ->
+  let (response, response_body) = get ~headers uri in
+    match response_body with
+    | Some resp -> 
+        let oc = open_out filepath in
+        Printf.fprintf oc "%s" resp;
+        echo "Wrote Data to Disk %d" (String.length resp);
+        close_out oc;
+        (response, response_body)
+    | _ -> 
+      (response, response_body)
+
+let get_header header = function (response, _) ->
+  let headers = response |> Cohttp.Response.headers in
+  let tag = Cohttp.Header.get headers header in
+  tag
+
+let header_create = Cohttp.Header.init
+
+let header_add name value = function h ->
+  Cohttp.Header.add h name value

--- a/src/main.ml
+++ b/src/main.ml
@@ -231,6 +231,15 @@ let main () =
     echo "0.1.0";
     exit 0
   );
+  let data_dir =
+    Clap.optional_string
+      ~long: "data-dir"
+      ~placeholder: "PATH"
+      ~description: "Path to data directory. \
+      On Linux, this defaults to: `~/.kalandralang/data/` \
+      On other Platforms, this currently defaults to `./data/`"
+      ()
+  in
   let command =
     Clap.subcommand [
       (
@@ -352,19 +361,6 @@ let main () =
                unspecified, read the recipe from stdin."
             ()
         in
-        let data_dir =
-          let dir = Clap.optional_string
-            ~long: "data-dir"
-            ~placeholder: "PATH"
-            ~description: "Path to custom data directory."
-            ()
-          in
-          match dir with
-            | None ->
-                String.empty
-            | Some dir ->
-                dir
-        in
         let display_options =
           {
             verbose;
@@ -438,19 +434,6 @@ let main () =
                case-insensitive."
             ()
         in
-        let data_dir =
-          let dir = Clap.optional_string
-            ~long: "data-dir"
-            ~placeholder: "PATH"
-            ~description: "Path to custom data directory."
-            ()
-          in
-          match dir with
-            | None ->
-                String.empty
-            | Some dir ->
-                dir
-        in
         `find (data_dir,pattern)
       );
       (
@@ -459,19 +442,6 @@ let main () =
             "Output default costs to data/costs.json. Warning: if you \
              customized this file, all your changes will be lost."
         @@ fun () ->
-        let data_dir =
-          let dir = Clap.optional_string
-            ~long: "data-dir"
-            ~placeholder: "PATH"
-            ~description: "Path to custom data directory."
-            ()
-          in
-          match dir with
-            | None ->
-                String.empty
-            | Some dir ->
-                dir
-        in
         `write_default_costs (data_dir)
       );
       (
@@ -496,40 +466,14 @@ let main () =
             ~description: "Folder name in The Forbidden Trove's repository."
             "lsc"
         in
-        let data_dir =
-          let dir = Clap.optional_string
-            ~long: "data-dir"
-            ~placeholder: "PATH"
-            ~description: "Path to custom data directory."
-            ()
-          in
-          match dir with
-            | None ->
-                String.empty
-            | Some dir ->
-                dir
-        in
         `update_costs (data_dir, ninja_league, tft_league)
       );
       (
-        Clap.case "update-cache"
+        Clap.case "update-data"
           ~description:
-            "TODO-ADD description"
+            "Updates RePoE Data (Datamined PoE Files) and creates a cached version."
         @@ fun () ->
-        let data_dir =
-          let dir = Clap.optional_string
-            ~long: "data-dir"
-            ~placeholder: "PATH"
-            ~description: "Path to custom data directory."
-            ()
-          in
-          match dir with
-            | None ->
-                String.empty
-            | Some dir ->
-                dir
-        in
-        `update_cache (data_dir)
+        `update_data (data_dir)
       );
     ]
   in
@@ -589,8 +533,8 @@ let main () =
         Data.write_default_costs data_dir
     | `update_costs (data_dir, ninja_league, tft_league) ->
         Data.update_costs data_dir ~ninja_league: ninja_league ~tft_league: tft_league
-    | `update_cache (data_dir) ->
-        Data.update_cache data_dir
+    | `update_data (data_dir) ->
+        Data.update_data data_dir
 
 let backtrace = false
 

--- a/src/misc.ml
+++ b/src/misc.ml
@@ -57,3 +57,14 @@ let memoize f =
           let y = f x in
           Hashtbl.add table x y;
           y
+
+let mkdir_p ~path ~perms =
+  let ps = String.split_on_char '/' path in
+  let rec aux acc = function [] -> ()
+  | p::ps ->
+      let this = String.concat Filename.dir_sep (List.rev (p::acc)) in
+      if this <> String.empty && not (Sys.file_exists this) then
+        Sys.mkdir this perms;
+      aux (p::acc) ps
+  in
+  aux [] ps

--- a/src/misc.ml
+++ b/src/misc.ml
@@ -13,6 +13,7 @@ let fail x = Printf.ksprintf failwith x
 let default x = function None -> x | Some x -> x
 let echo x = Format.kasprintf print_endline x
 let sf = Printf.sprintf
+let (//) = Filename.concat
 
 let random_from_pool pool =
   let total_weight = List.fold_left (fun acc (weight, _) -> acc + weight) 0 pool in
@@ -58,13 +59,8 @@ let memoize f =
           Hashtbl.add table x y;
           y
 
-let mkdir_p ~path ~perms =
-  let ps = String.split_on_char '/' path in
-  let rec aux acc = function [] -> ()
-  | p::ps ->
-      let this = String.concat Filename.dir_sep (List.rev (p::acc)) in
-      if this <> String.empty && not (Sys.file_exists this) then
-        Sys.mkdir this perms;
-      aux (p::acc) ps
-  in
-  aux [] ps
+let rec mkdir_p ?(perms = 0o755) path =
+  if not (Sys.file_exists path) then
+    let parent = Filename.dirname path in
+    if String.length parent < String.length path then mkdir_p ~perms parent;
+    Sys.mkdir path perms

--- a/src/ninja.ml
+++ b/src/ninja.ml
@@ -1,26 +1,6 @@
 (* USES uri *)
-(* USES tls *)
-(* USES cohttp-lwt-unix *)
-(* USES lwt *)
 
 open Misc
-
-let (let*) = Lwt.bind
-let return = Lwt.return
-
-let http_get uri =
-  Lwt_main.run @@
-  let* (response, response_body) = Cohttp_lwt_unix.Client.call `GET uri in
-  let* response_body = Cohttp_lwt.Body.to_string response_body in
-  match response.status with
-    | #Cohttp.Code.success_status ->
-        return (Some (JSON.parse ~origin: "poe.ninja's response" response_body))
-    | status ->
-        echo "failed to fetch %s: %s - %s"
-          (Uri.to_string uri)
-          (Cohttp.Code.string_of_status status)
-          response_body;
-        return None
 
 let as_currencies = function
   | None ->
@@ -44,7 +24,7 @@ let get_currencies league =
     "type", "Currency";
     "language", "en";
   ]
-  |> http_get
+  |> Http_request.get_json "poe.ninja response"
   |> as_currencies
 
 let as_items = function
@@ -69,7 +49,7 @@ let get_items ~league item_type =
     "type", item_type;
     "language", "en";
   ]
-  |> http_get
+  |> Http_request.get_json "poe.ninja response"
   |> as_items
 
 let get_essences league =
@@ -104,7 +84,7 @@ let get_tft league filename =
   Uri.of_string
     ("https://raw.githubusercontent.com/The-Forbidden-Trove/tft-data-prices/master/" ^
      league ^ "/" ^ filename)
-  |> http_get
+  |> Http_request.get_json "TFT response"
   |> as_tft
 
 let write_costs ~ninja_league ~tft_league ~filename =


### PR DESCRIPTION
Refactored Data and Http Requests

Key-Features:
 - On Unix Systems default folder in home directory for data files, enables users to use kalandralang everywhere `/home/<user>/.kalandralang/data/`
 - Downloading RePoE files
 - RePoE files only get downloaded if a new version is available (etag with If-None-Match in get request)
 - Easy way to add more RePoE files if needed (Just add to the list)
 - Http_requests are now mostly seperated from all the other logic
 - Added `--update-cache` to update the cache, which deletes the current cache file and tries to download RePoE files if they are more up to date, and creates a new cache file
 - Added `--data-dir <path>` to specify a directory to use for data storage, if a user wants to keep muliple data stroages  

Added bonus is if RePoE files get updated with the change of the cache version RePoE data gets forced onto users, so if a update drops we can change the cache version and update for the users if they still have old files around

What do you think? =)