### PR TITLE
feat: add veiled orb, remove aisling and veiled chaos

### DIFF
--- a/src/AST.ml
+++ b/src/AST.ml
@@ -75,6 +75,7 @@ type currency =
   | Redeemer_exalted_orb
   | Warlord_exalted_orb
   | Veiled_chaos_orb
+  | Veiled_orb
   | Essence of Essence.name
   | Fossils of Fossil.t list
   | Orb_of_dominance
@@ -135,6 +136,7 @@ let show_currency = function
   | Redeemer_exalted_orb -> "redeemer_exalt"
   | Warlord_exalted_orb -> "warlord_exalt"
   | Veiled_chaos_orb -> "veiled_chaos"
+  | Veiled_orb -> "veil"
   | Essence name -> "essence_of_" ^ Essence.show_name name
   | Fossils fossils -> String.concat " + " (List.map Fossil.show fossils)
   | Orb_of_dominance -> "orb_of_dominance"

--- a/src/cost.ml
+++ b/src/cost.ml
@@ -321,6 +321,9 @@ let beastcraft_split: field =
 let beastcraft_imprint: field =
   b "Craicic Chimeral" "beastcraft_imprint" 120.
 
+let veil: field =
+  c "Veiled Orb" "veil" (10. *. div)
+
 let aisling: field =
   s "T4 Aisling" "aisling" div
 
@@ -357,7 +360,10 @@ let get_currency (currency: AST.currency) =
     | Warlord_exalted_orb ->
         get warlord_exalt
     | Veiled_chaos_orb ->
+        (* legacy *)
         get veiled_chaos
+    | Veiled_orb ->
+        get veil
     | Essence Anger ->
         get essence_of_anger
     | Essence Anguish ->
@@ -589,6 +595,7 @@ let get_currency (currency: AST.currency) =
     | Beastcraft_imprint ->
         get beastcraft_imprint
     | Aisling ->
+        (* Aisling is now itemized as Veiled orb *)
         get aisling
     | Craft _ ->
         get transmute

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -513,6 +513,10 @@ let apply_currency state (currency: AST.currency) =
         with_item state @@ fun item ->
         item_must_be_rare item;
         return @@ Item.reforge_rare_with_veiled_mod item
+    | Veiled_orb ->
+        with_item state @@ fun item ->
+        item_must_be_rare item;
+        return @@ Item.remove_random_mod_add_veiled_mod item
     | Essence name ->
         with_item state @@ fun item ->
         let essence = Essence.by_name name in

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -80,6 +80,7 @@
     | "redeemer_exalt" -> CURRENCY Redeemer_exalted_orb
     | "warlord_exalt" -> CURRENCY Warlord_exalted_orb
     | "veiled_chaos" -> CURRENCY Veiled_chaos_orb
+    | "veil" -> CURRENCY Veiled_orb
     | "essence_of_anger" -> CURRENCY (Essence Anger)
     | "essence_of_anguish" -> CURRENCY (Essence Anguish)
     | "essence_of_contempt" -> CURRENCY (Essence Contempt)


### PR DESCRIPTION
Aisling and veiled chaos were removed, now aisling is crafted using veiled orb.

I left the old instructions in the lexer to give a meaningful error to existing users.