### PR TITLE
feat: use RePoE fork to support latest release of PoE

### DIFF
--- a/src/JSON.ml
+++ b/src/JSON.ml
@@ -64,6 +64,13 @@ let as_int json =
     | _ ->
         fail json "not a number"
 
+let as_int_opt json =
+  match json.json with
+    | `Float x ->
+       Some (int_of_float x)
+    | _ ->
+        None
+
 let as_float json =
   match json.json with
     | `Float x ->

--- a/src/JSON.mli
+++ b/src/JSON.mli
@@ -18,6 +18,8 @@ val as_bool: t -> bool
 
 val as_int: t -> int
 
+val as_int_opt: t -> int option
+
 val as_float: t -> float
 
 val as_float_opt: t -> float option

--- a/src/cache.ml
+++ b/src/cache.ml
@@ -400,6 +400,21 @@ let rec o_stat_translation_format o (x: Stat_translation.format) =
     | IH_divide_by_one_thousand y ->
         o_byte o 51;
         o_stat_translation_format o y
+    | IH_plus_two_hundred y ->
+        o_byte o 52;
+        o_stat_translation_format o y
+    | IH_divide_by_twenty y ->
+        o_byte o 53;
+        o_stat_translation_format o y
+    | IH_weapon_tree_unique_base_type_name y ->
+        o_byte o 54;
+        o_stat_translation_format o y
+    | IH_locations_to_metres y ->
+        o_byte o 55;
+        o_stat_translation_format o y
+    | IH_display_indexable_skill y ->
+        o_byte o 56;
+        o_stat_translation_format o y
 
 let rec i_stat_translation_format i: Stat_translation.format =
   match i_byte i with
@@ -557,6 +572,21 @@ let rec i_stat_translation_format i: Stat_translation.format =
     | 51 ->
         let y = i_stat_translation_format i in
         IH_divide_by_one_thousand y
+    | 52 ->
+        let y = i_stat_translation_format i in
+        IH_plus_two_hundred y
+    | 53 ->
+        let y = i_stat_translation_format i in
+        IH_divide_by_twenty y
+    | 54 ->
+        let y = i_stat_translation_format i in
+        IH_weapon_tree_unique_base_type_name y
+    | 55 ->
+        let y = i_stat_translation_format i in
+        IH_locations_to_metres y
+    | 56 ->
+        let y = i_stat_translation_format i in
+        IH_display_indexable_skill y
     | _ ->
         failwith "invalid stat translation format"
 

--- a/src/data.ml
+++ b/src/data.ml
@@ -142,7 +142,7 @@ let update_poe_data data_dir =
       echo "Updating: %s..." filename;
       let url =
         Uri.of_string
-          ("https://raw.githubusercontent.com/brather1ng/RePoE/master/RePoE/data/" ^ filename)
+          ("https://raw.githubusercontent.com/repoe-fork/repoe-fork.github.io/master/RePoE/data/" ^ filename)
       in
       let response, bytes = Http_request.download ~headers filepath url in
       Http_request.get_header "etag" response, bytes

--- a/src/essence.ml
+++ b/src/essence.ml
@@ -160,26 +160,26 @@ let load filename =
               level;
               on_amulet = JSON.(mods |-> "Amulet" |> as_id);
               on_belt = JSON.(mods |-> "Belt" |> as_id);
-              on_body_armour = JSON.(mods |-> "Body Armour" |> as_id);
+              on_body_armour = JSON.(mods |-> "Body_Armour" |> as_id);
               on_boots = JSON.(mods |-> "Boots" |> as_id);
               on_bow = JSON.(mods |-> "Bow" |> as_id);
               on_claw = JSON.(mods |-> "Claw" |> as_id);
               on_dagger = JSON.(mods |-> "Dagger" |> as_id);
               on_gloves = JSON.(mods |-> "Gloves" |> as_id);
               on_helmet = JSON.(mods |-> "Helmet" |> as_id);
-              on_one_hand_axe = JSON.(mods |-> "One Hand Axe" |> as_id);
-              on_one_hand_mace = JSON.(mods |-> "One Hand Mace" |> as_id);
-              on_one_hand_sword = JSON.(mods |-> "One Hand Sword" |> as_id);
+              on_one_hand_axe = JSON.(mods |-> "One_Hand_Axe" |> as_id);
+              on_one_hand_mace = JSON.(mods |-> "One_Hand_Mace" |> as_id);
+              on_one_hand_sword = JSON.(mods |-> "One_Hand_Sword" |> as_id);
               on_quiver = JSON.(mods |-> "Quiver" |> as_id);
               on_ring = JSON.(mods |-> "Ring" |> as_id);
               on_sceptre = JSON.(mods |-> "Sceptre" |> as_id);
               on_shield = JSON.(mods |-> "Shield" |> as_id);
               on_staff = JSON.(mods |-> "Staff" |> as_id);
               on_thrusting_one_hand_sword =
-                JSON.(mods |-> "Thrusting One Hand Sword" |> as_id);
-              on_two_hand_axe = JSON.(mods |-> "Two Hand Axe" |> as_id);
-              on_two_hand_mace = JSON.(mods |-> "Two Hand Mace" |> as_id);
-              on_two_hand_sword = JSON.(mods |-> "Two Hand Sword" |> as_id);
+                JSON.(mods |-> "Thrusting_One_Hand_Sword" |> as_id);
+              on_two_hand_axe = JSON.(mods |-> "Two_Hand_Axe" |> as_id);
+              on_two_hand_mace = JSON.(mods |-> "Two_Hand_Mace" |> as_id);
+              on_two_hand_sword = JSON.(mods |-> "Two_Hand_Sword" |> as_id);
               on_wand = JSON.(mods |-> "Wand" |> as_id);
             }
           in

--- a/src/stat_translation.ml
+++ b/src/stat_translation.ml
@@ -373,8 +373,8 @@ let load filename =
                 let min = ref None in
                 let handle_value (name, value) =
                   match name with
-                    | "max" -> max := Some (JSON.as_int value)
-                    | "min" -> min := Some (JSON.as_int value)
+                    | "max" -> max := (JSON.as_int_opt value)
+                    | "min" -> min := (JSON.as_int_opt value)
                     | _ -> ()
                 in
                 List.iter handle_value (JSON.as_object json);

--- a/src/stat_translation.ml
+++ b/src/stat_translation.ml
@@ -6,6 +6,7 @@ type format =
   | IH_30pct_of_value of format (* 30%_of_value *)
   | IH_60pct_of_value of format (* 60%_of_value *)
   | IH_deciseconds_to_seconds of format
+  | IH_plus_two_hundred of format
   | IH_divide_by_three of format
   | IH_divide_by_five of format
   | IH_divide_by_one_hundred of format
@@ -19,6 +20,7 @@ type format =
   | IH_divide_by_ten_1dp_if_required of format
   | IH_divide_by_twelve of format
   | IH_divide_by_fifteen_0dp of format
+  | IH_divide_by_twenty of format
   | IH_divide_by_twenty_then_double_0dp of format
   | IH_divide_by_fifty of format
   | IH_divide_by_one_hundred_2dp_if_required of format
@@ -53,6 +55,9 @@ type format =
   | IH_double of format
   | IH_negate_and_double of format
   | IH_metamorphosis_reward_description of format
+  | IH_weapon_tree_unique_base_type_name of format
+  | IH_locations_to_metres of format
+  | IH_display_indexable_skill of format
 
 type condition =
   {
@@ -105,6 +110,8 @@ let rec apply_format ?(omit_plus = false) f value =
         apply_format f (value *. 60. /. 100.)
     | IH_deciseconds_to_seconds f ->
         apply_format f (value /. 10.)
+    | IH_plus_two_hundred f ->
+        apply_format f (value +. 200.)
     | IH_divide_by_three f ->
         apply_format f (value /. 3.)
     | IH_divide_by_five f ->
@@ -131,6 +138,8 @@ let rec apply_format ?(omit_plus = false) f value =
         apply_format f (value /. 12.)
     | IH_divide_by_fifteen_0dp f ->
         apply_format f (round_0dp (value /. 15.))
+    | IH_divide_by_twenty f ->
+        apply_format f (value /. 20.)
     | IH_divide_by_twenty_then_double_0dp f ->
         apply_format f (round_0dp (value /. 20.) *. 2.)
     | IH_divide_by_fifty f ->
@@ -198,6 +207,12 @@ let rec apply_format ?(omit_plus = false) f value =
     | IH_negate_and_double f ->
         apply_format f (-. value *. 2.)
     | IH_metamorphosis_reward_description f ->
+        apply_format f value
+    | IH_weapon_tree_unique_base_type_name f ->
+        apply_format f value
+    | IH_locations_to_metres f ->
+        apply_format f value
+    | IH_display_indexable_skill f ->
         apply_format f value
 
 type translate_mode =
@@ -417,6 +432,8 @@ let load filename =
                   IH_60pct_of_value format
               | "deciseconds_to_seconds" ->
                   IH_deciseconds_to_seconds format
+              | "plus_two_hundred" ->
+                  IH_plus_two_hundred format
               | "divide_by_three" ->
                   IH_divide_by_three format
               | "divide_by_five" ->
@@ -443,6 +460,8 @@ let load filename =
                   IH_divide_by_twelve format
               | "divide_by_fifteen_0dp" ->
                   IH_divide_by_fifteen_0dp format
+              | "divide_by_twenty" ->
+                  IH_divide_by_twenty format
               | "divide_by_twenty_then_double_0dp" ->
                   IH_divide_by_twenty_then_double_0dp format
               | "divide_by_fifty" ->
@@ -511,6 +530,12 @@ let load filename =
                   IH_negate_and_double format
               | "metamorphosis_reward_description" ->
                   IH_metamorphosis_reward_description format
+              | "weapon_tree_unique_base_type_name" ->
+                  IH_weapon_tree_unique_base_type_name format
+              | "locations_to_metres" ->
+                  IH_locations_to_metres format
+              | "display_indexable_skill" ->
+                  IH_display_indexable_skill format
               | s ->
                   Printf.printf "Warning: %s: unknown format: %s\n%!"
                     (JSON.show_origin json) s;


### PR DESCRIPTION
Apparently the fork actually uses the dat-schema project to generate schemas for PyPoe to extract the data, and it seems to be quite well automated.  For now obviously using this is better than using the 3 years old version, but I think it will be maintained in the future as well.

- [x] Do I need to also update the cache version here?
- [x] new stat translation functions
  - [x] display_indexable_skill
  - [x] divide_by_twenty
  - [x] locations_to_metres
  - [x] plus_two_hundred
  - [x] weapon_tree_unique_base_type_name



Fixes #32