### PR TITLE
fix: update eldritch implicit generation types

### DIFF
--- a/src/mod.ml
+++ b/src/mod.ml
@@ -246,7 +246,11 @@ let load filename =
                       generation_type := Some `Suffix
                   | "eater_implicit" ->
                       generation_type := Some `Eater_implicit
+                  | "archnemesis" ->
+                      generation_type := Some `Eater_implicit
                   | "exarch_implicit" ->
+                      generation_type := Some `Exarch_implicit
+                  | "searing_exarch_implicit" ->
                       generation_type := Some `Exarch_implicit
                   | _ ->
                       ()


### PR DESCRIPTION
For some reason RePoE now marks the implicits with different generation types, eater is `archnemesis` and exarch is `searing_exarch_implicit`.  I kept also the old "normal" identifiers if it changes again (I filed a bug report to them).  This fixes implicit crafting which was completely broken (there were no mods at all so it would always crash with "item can't spawn any mods".