### PR TITLE
Make it possible to mix fractured and eldritch influences

### DIFF
--- a/src/AST.ml
+++ b/src/AST.ml
@@ -258,7 +258,7 @@ let pp_buy { exact; rarity; influence; base; ilvl; mods; cost } =
         match influence with
           | Not_influenced ->
               empty
-          | Fractured ->
+          | Fractured _ ->
               seq [ atom "fractured"; space ]
           | Synthesized ->
               seq [ atom "synthesized"; space ]

--- a/src/AST.ml
+++ b/src/AST.ml
@@ -266,11 +266,11 @@ let pp_buy { exact; rarity; influence; base; ilvl; mods; cost } =
               seq [ pp_sec_influence sec; space ]
           | SEC_pair (sec1, sec2) ->
               seq [ pp_sec_influence sec1; space; pp_sec_influence sec2; space ]
-          | Exarch ->
+          | Eldritch Exarch ->
               seq [ atom "exarch"; space ]
-          | Eater ->
+          | Eldritch Eater ->
               seq [ atom "eater"; space ]
-          | Exarch_and_eater ->
+          | Eldritch Exarch_and_eater ->
               seq [ atom "exarch"; space; atom "eater"; space ]
       );
       Id.pp base;

--- a/src/influence.ml
+++ b/src/influence.ml
@@ -42,7 +42,6 @@ let add_eldritch a b =
 
 let compare_sec = (Stdlib.compare: sec -> sec -> int)
 
-(* TODO: fractured + exarch / eater (don't forget to update [includes]) *)
 type t =
   | Not_influenced
   | Fractured of eld option
@@ -99,13 +98,13 @@ let add a b =
         fail "cannot have both Eldritch and Shaper / Elder / Conqueror influences"
 
 (* [a] includes [b] *)
-let includes a b =
+let rec includes a b =
   match a, b with
     | Not_influenced, Not_influenced -> true
     | Not_influenced, _ -> false
     | Fractured _, Fractured None -> true
-    | Fractured (Some eld1), Fractured (Some eld2) when eld1 == eld2 -> true
-    | Fractured (Some Exarch_and_eater), Fractured _ -> true
+    | Fractured (Some eld1), Fractured (Some eld2) -> includes (Eldritch eld1) (Eldritch eld2)
+    | Fractured (Some eld1), Eldritch eld2 -> includes (Eldritch eld1) (Eldritch eld2)
     | Fractured _, _ -> false
     | Synthesized, Synthesized -> true
     | Synthesized, _ -> false

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -363,7 +363,7 @@ let check_can_apply_conqueror_exalt (item: Item.t) =
     | Synthesized ->
         fail "cannot use a conqueror exalted orb on a synthesized item"
     | SEC _ | SEC_pair _
-    | Exarch | Eater | Exarch_and_eater ->
+    | Eldritch _ ->
         fail "cannot use a conqueror exalted orb on an influenced item"
 
 let item_cannot_be_split (item: Item.t) =
@@ -553,7 +553,7 @@ let apply_currency state (currency: AST.currency) =
                 x
             | SEC_pair _ ->
                 fail "%s has more than one influence" name
-            | Not_influenced | Exarch | Eater | Exarch_and_eater | Synthesized | Fractured _ ->
+            | Not_influenced | Eldritch _ | Synthesized | Fractured _ ->
                 fail "%s does not have a Shaper / Elder / Conqueror influence" name
         in
         let item_influence = get_sec_influence "current item" item in
@@ -624,7 +624,7 @@ let apply_currency state (currency: AST.currency) =
         item_must_be_rare item;
         (
           match item.influence with
-            | Not_influenced | Exarch | Eater | Exarch_and_eater ->
+            | Not_influenced | Eldritch _ ->
                 ()
             | Synthesized | Fractured _ | SEC _ | SEC_pair _ ->
                 fail "cannot fracture influenced, synthesized, and already-fractured items"
@@ -638,7 +638,7 @@ let apply_currency state (currency: AST.currency) =
           match item.influence with
             | Not_influenced | Synthesized | Fractured _ ->
                 ()
-            | SEC _ | SEC_pair _ | Exarch | Eater | Exarch_and_eater ->
+            | SEC _ | SEC_pair _ | Eldritch _ ->
                 fail "cannot harvest augment an influenced item"
         );
         return @@ Item.harvest_augment_and_remove ~tag item
@@ -648,7 +648,7 @@ let apply_currency state (currency: AST.currency) =
           match item.influence with
             | Not_influenced | Synthesized | Fractured _ ->
                 ()
-            | SEC _ | SEC_pair _ | Exarch | Eater | Exarch_and_eater ->
+            | SEC _ | SEC_pair _ | Eldritch _ ->
                 fail "cannot harvest non-X to X an influenced item"
         );
         let item =
@@ -703,7 +703,8 @@ let apply_currency state (currency: AST.currency) =
                 fail "cannot split a fractured item"
             | Synthesized ->
                 fail "cannot split a synthesized item"
-            | SEC _ | SEC_pair _ | Exarch | Eater | Exarch_and_eater ->
+            (* TODO: eldritch items can in fact be split *)
+            | SEC _ | SEC_pair _ | Eldritch _ ->
                 fail "cannot split an influenced item"
         );
         let item1, item2 = Item.split item in
@@ -715,7 +716,7 @@ let apply_currency state (currency: AST.currency) =
         (
           match item.influence with
             | Not_influenced | Synthesized
-            | SEC _ | SEC_pair _ | Exarch | Eater | Exarch_and_eater ->
+            | SEC _ | SEC_pair _ | Eldritch _ ->
                 ()
             | Fractured _ ->
                 fail "cannot imprint a fractured item"

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -358,7 +358,7 @@ let item_must_be_normal_or_magic (item: Item.t) =
 let check_can_apply_conqueror_exalt (item: Item.t) =
   match item.influence with
     | Not_influenced -> ()
-    | Fractured ->
+    | Fractured _ ->
         fail "cannot use a conqueror exalted orb on a fractured item"
     | Synthesized ->
         fail "cannot use a conqueror exalted orb on a synthesized item"
@@ -553,7 +553,7 @@ let apply_currency state (currency: AST.currency) =
                 x
             | SEC_pair _ ->
                 fail "%s has more than one influence" name
-            | Not_influenced | Exarch | Eater | Exarch_and_eater | Synthesized | Fractured ->
+            | Not_influenced | Exarch | Eater | Exarch_and_eater | Synthesized | Fractured _ ->
                 fail "%s does not have a Shaper / Elder / Conqueror influence" name
         in
         let item_influence = get_sec_influence "current item" item in
@@ -624,10 +624,9 @@ let apply_currency state (currency: AST.currency) =
         item_must_be_rare item;
         (
           match item.influence with
-            | Not_influenced ->
+            | Not_influenced | Exarch | Eater | Exarch_and_eater ->
                 ()
-            | Synthesized | Fractured | SEC _ | SEC_pair _
-            | Exarch | Eater | Exarch_and_eater ->
+            | Synthesized | Fractured _ | SEC _ | SEC_pair _ ->
                 fail "cannot fracture influenced, synthesized, and already-fractured items"
         );
         if List.length (List.filter Item.is_prefix_or_suffix item.mods) < 4 then
@@ -637,7 +636,7 @@ let apply_currency state (currency: AST.currency) =
         with_item state @@ fun item ->
         (
           match item.influence with
-            | Not_influenced | Synthesized | Fractured ->
+            | Not_influenced | Synthesized | Fractured _ ->
                 ()
             | SEC _ | SEC_pair _ | Exarch | Eater | Exarch_and_eater ->
                 fail "cannot harvest augment an influenced item"
@@ -647,7 +646,7 @@ let apply_currency state (currency: AST.currency) =
         with_item state @@ fun item ->
         (
           match item.influence with
-            | Not_influenced | Synthesized | Fractured ->
+            | Not_influenced | Synthesized | Fractured _ ->
                 ()
             | SEC _ | SEC_pair _ | Exarch | Eater | Exarch_and_eater ->
                 fail "cannot harvest non-X to X an influenced item"
@@ -700,7 +699,7 @@ let apply_currency state (currency: AST.currency) =
           match item.influence with
             | Not_influenced ->
                 ()
-            | Fractured ->
+            | Fractured _ ->
                 fail "cannot split a fractured item"
             | Synthesized ->
                 fail "cannot split a synthesized item"
@@ -718,7 +717,7 @@ let apply_currency state (currency: AST.currency) =
             | Not_influenced | Synthesized
             | SEC _ | SEC_pair _ | Exarch | Eater | Exarch_and_eater ->
                 ()
-            | Fractured ->
+            | Fractured _ ->
                 fail "cannot imprint a fractured item"
         );
         let state = return item in
@@ -831,7 +830,7 @@ let run_simple_instruction state loc (instruction: AST.simple_instruction) =
         let item = Item.make base_obj ilvl ?rarity influence in
         let item =
           let add_mod item ({ modifier; fractured }: AST.buy_with) =
-            let item = if fractured then Item.add_influence Fractured item else item in
+            let item = if fractured then Item.add_influence (Fractured None) item else item in
             Item.add_mod ~fractured (Mod.by_id modifier) item
           in
           List.fold_left add_mod item mods

--- a/src/item.ml
+++ b/src/item.ml
@@ -332,8 +332,14 @@ let show item =
     match item.influence with
       | Not_influenced ->
           ""
-      | Fractured ->
+      | Fractured None ->
           " (Fractured)"
+      | Fractured (Some Exarch) ->
+          " (Fractured Exarch)"
+      | Fractured (Some Eater) ->
+          " (Fractured Eater)"
+      | Fractured (Some Exarch_and_eater) ->
+          " (Fractured Exarch / Eater)"
       | Synthesized ->
           " (Synthesized)"
       | SEC sec ->
@@ -748,7 +754,7 @@ let add_influence influence item =
         item |> add_sec_influence_tag sec
     | SEC_pair (sec1, sec2) ->
         item |> add_sec_influence_tag sec1 |> add_sec_influence_tag sec2
-    | Not_influenced | Fractured | Synthesized | Exarch | Eater | Exarch_and_eater ->
+    | Not_influenced | Fractured _ | Synthesized | Exarch | Eater | Exarch_and_eater ->
         item
 
 let make ?rarity base level influence =
@@ -994,7 +1000,7 @@ let apply_orb_of_dominance item =
       | SEC x -> [ x ]
       | SEC_pair (x, y) -> [ x; y ]
       | Not_influenced
-      | Fractured
+      | Fractured _
       | Synthesized
       | Exarch
       | Eater
@@ -1079,7 +1085,7 @@ let apply_orb_of_dominance item =
 let get_influence_tags item =
   match item.influence with
     | Not_influenced
-    | Fractured
+    | Fractured _
     | Synthesized
     | Exarch
     | Eater
@@ -1258,4 +1264,4 @@ let apply_fracturing_orb item =
       incr current_index;
       m
     in
-    { item with mods; influence = Influence.add item.influence Fractured }
+    { item with mods; influence = Influence.add item.influence (Fractured None) }

--- a/src/item.ml
+++ b/src/item.ml
@@ -346,11 +346,11 @@ let show item =
           " (" ^ Influence.show_sec sec ^ ")"
       | SEC_pair (sec1, sec2) ->
           " (" ^ Influence.show_sec sec1 ^ " / " ^ Influence.show_sec sec2 ^ ")"
-      | Exarch ->
+      | Eldritch Exarch ->
           " (Exarch)"
-      | Eater ->
+      | Eldritch Eater ->
           " (Eater)"
-      | Exarch_and_eater ->
+      | Eldritch Exarch_and_eater ->
           " (Exarch / Eater)"
   in
   let split = if item.split then [ "Split" ] else [] in
@@ -754,7 +754,7 @@ let add_influence influence item =
         item |> add_sec_influence_tag sec
     | SEC_pair (sec1, sec2) ->
         item |> add_sec_influence_tag sec1 |> add_sec_influence_tag sec2
-    | Not_influenced | Fractured _ | Synthesized | Exarch | Eater | Exarch_and_eater ->
+    | Not_influenced | Fractured _ | Synthesized | Eldritch _ ->
         item
 
 let make ?rarity base level influence =
@@ -877,13 +877,13 @@ let spawn_random_eater_implicit tier item =
 
 let apply_eldritch_ichor tier item =
   item
-  |> add_influence Eater
+  |> add_influence (Eldritch Eater)
   |> remove_all_implicits_except_exarch
   |> spawn_random_eater_implicit tier
 
 let apply_eldritch_ember tier item =
   item
-  |> add_influence Exarch
+  |> add_influence (Eldritch Exarch)
   |> remove_all_implicits_except_eater
   |> spawn_random_exarch_implicit tier
 
@@ -1002,9 +1002,7 @@ let apply_orb_of_dominance item =
       | Not_influenced
       | Fractured _
       | Synthesized
-      | Exarch
-      | Eater
-      | Exarch_and_eater ->
+      | Eldritch _ ->
           fail "item does not have a Shaper / Elder / Conqueror influence"
   in
   let candidates =
@@ -1087,9 +1085,7 @@ let get_influence_tags item =
     | Not_influenced
     | Fractured _
     | Synthesized
-    | Exarch
-    | Eater
-    | Exarch_and_eater ->
+    | Eldritch _ ->
         Id.Set.empty
     | SEC sec ->
         (

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -57,8 +57,8 @@ influence:
 | HUNTER { Influence.SEC Hunter }
 | REDEEMER { Influence.SEC Redeemer }
 | WARLORD { Influence.SEC Warlord }
-| EXARCH { Influence.Exarch }
-| EATER { Influence.Eater }
+| EXARCH { Influence.Eldritch Exarch }
+| EATER { Influence.Eldritch Eater }
 | SYNTHESIZED { Influence.Synthesized }
 | FRACTURED { Influence.Fractured None }
 

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -60,7 +60,7 @@ influence:
 | EXARCH { Influence.Exarch }
 | EATER { Influence.Eater }
 | SYNTHESIZED { Influence.Synthesized }
-| FRACTURED { Influence.Fractured }
+| FRACTURED { Influence.Fractured None }
 
 buy_arguments:
 | EXACT buy_arguments


### PR DESCRIPTION
This patch introduces some changes to how influences are tracked to allow fracturing eldritch influenced items

* Extract eldritch influences to a subtype similar to `sec` called `eld`
* Change `Fractured` to a compound type `Fractured of eld option` -> This allows us to track both fracturing and eldritch influences
* Replace direct eldritch influences with `Eldritch of eld` -> simplifies the logic and allows us to mix `Fractured (Some x)` and `Eldritch y`

Now we can run recipes like

```
buy "Metadata/Items/Armours/BodyArmours/BodyDexInt20"

fracture
lesser_ichor
show
lesser_ember
```

and also

```
buy "Metadata/Items/Armours/BodyArmours/BodyDexInt20"

lesser_ichor
fracture
show
lesser_ember
```